### PR TITLE
19 feature gpt api 도입

### DIFF
--- a/src/main/java/org/dive2025/qdeep/common/config/GptConfig.java
+++ b/src/main/java/org/dive2025/qdeep/common/config/GptConfig.java
@@ -1,0 +1,25 @@
+package org.dive2025.qdeep.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class GptConfig {
+
+    @Value("${openai.api.key}")
+    private String oepnAiKey;
+
+    @Bean
+    public RestTemplate restTemplate(){
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.getInterceptors()
+                .add(((request, body, execution) -> {
+            request.getHeaders().add("Authorization", "Bearer " + oepnAiKey);
+            return execution.execute(request,body);
+        })
+                );
+        return restTemplate;
+    }
+}

--- a/src/main/java/org/dive2025/qdeep/common/config/SecurityConfig.java
+++ b/src/main/java/org/dive2025/qdeep/common/config/SecurityConfig.java
@@ -97,6 +97,7 @@ public class SecurityConfig {
                 .requestMatchers("/login", "/user/create", "/user/check-nickname", "/user/check-username").permitAll()
                 .requestMatchers("/refresh").permitAll()
                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                .requestMatchers("/gpt/**").permitAll()
                 .anyRequest().authenticated()
         );
 

--- a/src/main/java/org/dive2025/qdeep/common/exception/ErrorCode.java
+++ b/src/main/java/org/dive2025/qdeep/common/exception/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 사용자를 찾을 수 없습니다."),
     USER_USERNAME_DUPLICATED(HttpStatus.CONFLICT,"해당 아이디는 이미 존재합니다."),
     USER_NICKNAME_DUPLICATED(HttpStatus.CONFLICT,"해당 닉네임은 이미 존재합니다."),
-    USER_NICKNAME_UNSATISFIED(HttpStatus.BAD_REQUEST,"닉네임 형식에 맞지 않습니다.");
+    USER_NICKNAME_UNSATISFIED(HttpStatus.BAD_REQUEST,"닉네임 형식에 맞지 않습니다."),
+    GPT_RESPONSE_NOT_FOUND(HttpStatus.NOT_FOUND,"gpt API의 결과값을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/dive2025/qdeep/common/infra/gpt/client/GptClient.java
+++ b/src/main/java/org/dive2025/qdeep/common/infra/gpt/client/GptClient.java
@@ -1,0 +1,23 @@
+package org.dive2025.qdeep.common.infra.gpt.client;
+
+import org.dive2025.qdeep.common.infra.gpt.dto.GptRequest;
+import org.dive2025.qdeep.common.infra.gpt.dto.GptResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class GptClient {
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Value("${openai.api.url}")
+    private String url;
+
+    public GptResponse sendMessage(GptRequest request){
+        return restTemplate.postForObject(url, request, GptResponse.class);
+    }
+
+}

--- a/src/main/java/org/dive2025/qdeep/common/infra/gpt/dto/GptRequest.java
+++ b/src/main/java/org/dive2025/qdeep/common/infra/gpt/dto/GptRequest.java
@@ -4,10 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 
-public record GptRequest(String model, List<Message> messages) {
+public record GptRequest(String model, String input) {
 
-    public GptRequest(String model,String prompt){
-        this(model,new ArrayList<>(List.of(new Message("user",prompt))));
-    }
 
 }

--- a/src/main/java/org/dive2025/qdeep/common/infra/gpt/dto/GptRequest.java
+++ b/src/main/java/org/dive2025/qdeep/common/infra/gpt/dto/GptRequest.java
@@ -1,0 +1,13 @@
+package org.dive2025.qdeep.common.infra.gpt.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+public record GptRequest(String model, List<Message> messages) {
+
+    public GptRequest(String model,String prompt){
+        this(model,new ArrayList<>(List.of(new Message("user",prompt))));
+    }
+
+}

--- a/src/main/java/org/dive2025/qdeep/common/infra/gpt/dto/GptResponse.java
+++ b/src/main/java/org/dive2025/qdeep/common/infra/gpt/dto/GptResponse.java
@@ -1,0 +1,12 @@
+package org.dive2025.qdeep.common.infra.gpt.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+public record GptResponse(List<Choice> choices) {
+
+    public record Choice(int index,Message message){
+
+    }
+}

--- a/src/main/java/org/dive2025/qdeep/common/infra/gpt/dto/GptResponse.java
+++ b/src/main/java/org/dive2025/qdeep/common/infra/gpt/dto/GptResponse.java
@@ -4,9 +4,24 @@ import lombok.Getter;
 
 import java.util.List;
 
-public record GptResponse(List<Choice> choices) {
+public record GptResponse(
+        String id,
+        String object,
+        long created,
+        String model,
+        List<Output> output) {
 
-    public record Choice(int index,Message message){
+    public record Output(
+            String id,
+            String type,
+            String role,
+            List<Content> content) {
+
+    }
+
+    public record Content(
+            String type,
+            String text) {
 
     }
 }

--- a/src/main/java/org/dive2025/qdeep/common/infra/gpt/dto/Message.java
+++ b/src/main/java/org/dive2025/qdeep/common/infra/gpt/dto/Message.java
@@ -1,5 +1,0 @@
-package org.dive2025.qdeep.common.infra.gpt.dto;
-
-public record Message(String role,String content) {
-
-}

--- a/src/main/java/org/dive2025/qdeep/common/infra/gpt/dto/Message.java
+++ b/src/main/java/org/dive2025/qdeep/common/infra/gpt/dto/Message.java
@@ -1,0 +1,5 @@
+package org.dive2025.qdeep.common.infra.gpt.dto;
+
+public record Message(String role,String content) {
+
+}

--- a/src/main/java/org/dive2025/qdeep/common/security/filter/JwtFilter.java
+++ b/src/main/java/org/dive2025/qdeep/common/security/filter/JwtFilter.java
@@ -49,6 +49,7 @@ public class JwtFilter extends OncePerRequestFilter {
                 antPathMatcher.match("/user/check-nickname", path) ||
                 antPathMatcher.match("/user/check-username", path) ||
                 antPathMatcher.match("/swagger-ui/**", path) ||
+                antPathMatcher.match("/gpt/**",path)||
                 antPathMatcher.match("/v3/api-docs/**", path);
     }
 

--- a/src/main/java/org/dive2025/qdeep/domain/recommend/controller/GptController.java
+++ b/src/main/java/org/dive2025/qdeep/domain/recommend/controller/GptController.java
@@ -1,0 +1,30 @@
+package org.dive2025.qdeep.domain.recommend.controller;
+
+import org.dive2025.qdeep.common.infra.gpt.client.GptClient;
+import org.dive2025.qdeep.common.infra.gpt.dto.GptRequest;
+import org.dive2025.qdeep.common.infra.gpt.dto.GptResponse;
+import org.dive2025.qdeep.domain.recommend.dto.response.GptClientResponse;
+import org.dive2025.qdeep.domain.recommend.service.GptService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/gpt")
+public class GptController {
+
+    @Autowired
+    private GptService gptService;
+    @PostMapping("/chat")
+    public ResponseEntity<GptClientResponse> chat(@RequestParam(name = "prompt")String prompt){
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(gptService.processRequest(prompt));
+
+    }
+
+}

--- a/src/main/java/org/dive2025/qdeep/domain/recommend/dto/response/GptClientResponse.java
+++ b/src/main/java/org/dive2025/qdeep/domain/recommend/dto/response/GptClientResponse.java
@@ -1,5 +1,6 @@
 package org.dive2025.qdeep.domain.recommend.dto.response;
+import java.util.List;
 
-public record GptClientResponse(String reslut,
+public record GptClientResponse(List<String> reslut,
                                 String timeStamp) {
 }

--- a/src/main/java/org/dive2025/qdeep/domain/recommend/dto/response/GptClientResponse.java
+++ b/src/main/java/org/dive2025/qdeep/domain/recommend/dto/response/GptClientResponse.java
@@ -1,0 +1,5 @@
+package org.dive2025.qdeep.domain.recommend.dto.response;
+
+public record GptClientResponse(String reslut,
+                                String timeStamp) {
+}

--- a/src/main/java/org/dive2025/qdeep/domain/recommend/service/GptService.java
+++ b/src/main/java/org/dive2025/qdeep/domain/recommend/service/GptService.java
@@ -1,0 +1,37 @@
+package org.dive2025.qdeep.domain.recommend.service;
+
+import org.dive2025.qdeep.common.infra.gpt.client.GptClient;
+import org.dive2025.qdeep.common.infra.gpt.dto.GptRequest;
+import org.dive2025.qdeep.common.infra.gpt.dto.GptResponse;
+import org.dive2025.qdeep.domain.recommend.dto.response.GptClientResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class GptService {
+
+    @Autowired
+    private GptClient gptClient;
+
+    @Value("${openai.model}")
+    private String model;
+
+    public GptClientResponse processRequest(String prompt){
+
+        String reuslt =  gptClient
+                .sendMessage(new GptRequest(model,prompt))
+                .choices()
+                .get(0)
+                .message()
+                .content();
+
+        return new GptClientResponse(reuslt,
+                LocalDateTime.now().toString());
+
+    }
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,9 @@ spring:
 
   jwt:
     secret: ${JWT_SECRET} # JWT SECRET키
+
+openai:
+  model : gpt-3.5-turbo
+  api :
+    key : ${OPENAI_API_KEY}
+    url : https://api.openai.com/v1/responses


### PR DESCRIPTION
## 📌 Related Issue

> 관련된 이슈 번호를 적어주세요.  
> 예시: Close 프로젝트 패키지명 변경 #22

- Close #19 

---

## 💬 Description

> 작업한 내용을 간략히 적어주세요.  
> 예시: demo → lettie로 패키지명 변경

1. ChatGPT API 세팅을 위한 기본 설정 

- GptConfig.class : API key + Bearer 을 자동으로 설정 
- GptClient.class : Gpt API의 엔드포인트에 API요청을 대행해주는 클라이언트 클래스 
- GptRequest.class , GptResponse.class : Gpt API에 대한 요청/응답 규격 DTO 

2. ChatGPT API 커스터마이징 

- GptController.class , GptClientResponse , GptService : 요청한 Gpt API의 결과값에 대하여 프론트엔드 요청 작업에 커스텀화한 MVC 구성 

## 📸 Screenshot

> 변경 사항을 보여주는 스크린샷(또는 GIF)을 첨부해 주세요.  
> 예시: UI 변경 시 Before/After 캡처

<img width="992" height="557" alt="스크린샷 2025-08-21 오후 3 13 54" src="https://github.com/user-attachments/assets/30cfa704-f68a-4b99-afbb-6028d1fd0b5e" />




## 📢 Notes

> 추가적인 설명이나 참고 사항을 작성해 주세요.  
> 예시: 마이그레이션 주의사항, 의도적인 비동기 처리 등

- 해커톤 당일 input에 대한 프롬프트 작업 필요  
