### PR TITLE
21 refactor gpt api 응답 결과값 커스텀화 및 요청방식 변경

### DIFF
--- a/src/main/java/org/dive2025/qdeep/common/infra/gpt/dto/GptRequest.java
+++ b/src/main/java/org/dive2025/qdeep/common/infra/gpt/dto/GptRequest.java
@@ -1,10 +1,14 @@
 package org.dive2025.qdeep.common.infra.gpt.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 
-public record GptRequest(String model, String input) {
+public record GptRequest(String model,
+                         String input) {
 
 
 }

--- a/src/main/java/org/dive2025/qdeep/domain/recommend/controller/GptController.java
+++ b/src/main/java/org/dive2025/qdeep/domain/recommend/controller/GptController.java
@@ -1,15 +1,17 @@
 package org.dive2025.qdeep.domain.recommend.controller;
 
-import org.dive2025.qdeep.common.infra.gpt.client.GptClient;
-import org.dive2025.qdeep.common.infra.gpt.dto.GptRequest;
-import org.dive2025.qdeep.common.infra.gpt.dto.GptResponse;
-import org.dive2025.qdeep.domain.recommend.dto.response.GptClientResponse;
+import org.dive2025.qdeep.domain.recommend.dto.request.GptClientRequest;
+import org.dive2025.qdeep.domain.recommend.dto.request.PromptInputRequest;
+import org.dive2025.qdeep.domain.recommend.dto.response.RecommendationSaveResponse;
 import org.dive2025.qdeep.domain.recommend.service.GptService;
+import org.dive2025.qdeep.domain.store.dto.response.SavedStoreResponse;
+import org.dive2025.qdeep.domain.store.service.StoreService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 
 @RestController
@@ -17,13 +19,19 @@ import org.springframework.web.bind.annotation.*;
 public class GptController {
 
     @Autowired
+    private StoreService storeService;
+    @Autowired
     private GptService gptService;
+
     @PostMapping("/chat")
-    public ResponseEntity<GptClientResponse> chat(@RequestParam(name = "prompt")String prompt){
+    public ResponseEntity<List<SavedStoreResponse>> chat(@RequestBody PromptInputRequest promptInputRequest){
 
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(gptService.processRequest(prompt));
+                .body(storeService.saveAllResponsesBatch(
+                        gptService
+                                .processRequest(gptService
+                                .prompting(promptInputRequest))));
 
     }
 

--- a/src/main/java/org/dive2025/qdeep/domain/recommend/dto/request/GptClientRequest.java
+++ b/src/main/java/org/dive2025/qdeep/domain/recommend/dto/request/GptClientRequest.java
@@ -1,0 +1,6 @@
+package org.dive2025.qdeep.domain.recommend.dto.request;
+
+public record GptClientRequest(String prompt) {
+
+
+}

--- a/src/main/java/org/dive2025/qdeep/domain/recommend/dto/request/PromptInputRequest.java
+++ b/src/main/java/org/dive2025/qdeep/domain/recommend/dto/request/PromptInputRequest.java
@@ -1,0 +1,6 @@
+package org.dive2025.qdeep.domain.recommend.dto.request;
+
+public record PromptInputRequest(String address,
+                                 String hours,
+                                 String category) {
+}

--- a/src/main/java/org/dive2025/qdeep/domain/recommend/dto/response/GptClientResponse.java
+++ b/src/main/java/org/dive2025/qdeep/domain/recommend/dto/response/GptClientResponse.java
@@ -1,6 +1,0 @@
-package org.dive2025.qdeep.domain.recommend.dto.response;
-import java.util.List;
-
-public record GptClientResponse(List<String> reslut,
-                                String timeStamp) {
-}

--- a/src/main/java/org/dive2025/qdeep/domain/recommend/dto/response/RecommendationResponse.java
+++ b/src/main/java/org/dive2025/qdeep/domain/recommend/dto/response/RecommendationResponse.java
@@ -1,0 +1,9 @@
+package org.dive2025.qdeep.domain.recommend.dto.response;
+
+public record RecommendationResponse(String name,
+                                     String address,
+                                     String hours,
+                                     String description,
+                                     double latitude,
+                                     double longitude) {
+}

--- a/src/main/java/org/dive2025/qdeep/domain/recommend/dto/response/RecommendationSaveResponse.java
+++ b/src/main/java/org/dive2025/qdeep/domain/recommend/dto/response/RecommendationSaveResponse.java
@@ -1,0 +1,6 @@
+package org.dive2025.qdeep.domain.recommend.dto.response;
+
+public record RecommendationSaveResponse(String name,
+                                         String address,
+                                         String hours) {
+}

--- a/src/main/java/org/dive2025/qdeep/domain/recommend/service/GptService.java
+++ b/src/main/java/org/dive2025/qdeep/domain/recommend/service/GptService.java
@@ -1,47 +1,112 @@
 package org.dive2025.qdeep.domain.recommend.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.dive2025.qdeep.common.exception.CustomException;
 import org.dive2025.qdeep.common.exception.ErrorCode;
 import org.dive2025.qdeep.common.infra.gpt.client.GptClient;
 import org.dive2025.qdeep.common.infra.gpt.dto.GptRequest;
 import org.dive2025.qdeep.common.infra.gpt.dto.GptResponse;
-import org.dive2025.qdeep.domain.recommend.dto.response.GptClientResponse;
+import org.dive2025.qdeep.domain.recommend.dto.request.GptClientRequest;
+import org.dive2025.qdeep.domain.recommend.dto.request.PromptInputRequest;
+import org.dive2025.qdeep.domain.recommend.dto.response.RecommendationResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 public class GptService {
 
     @Autowired
     private GptClient gptClient;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @Value("${openai.model}")
     private String model;
 
-    public GptClientResponse processRequest(String prompt){
+    //
+    public List<RecommendationResponse> processRequest(GptClientRequest gptClientRequest){
+
 
         GptResponse gptResponse =  gptClient
-                .sendMessage(new GptRequest(model,prompt));
+                .sendMessage(new GptRequest(model,
+                        gptClientRequest.prompt()));
 
-        List<String> content = gptResponse.output()
+        System.out.println(gptResponse);
+
+        String jsonText = gptResponse.output()
                 .stream()
                 .findFirst()
                 .orElseThrow(() -> new CustomException(ErrorCode.GPT_RESPONSE_NOT_FOUND))
                 .content()
                 .stream()
-                .map(GptResponse.Content::text)
-                .collect(Collectors
-                        .toList());
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.GPT_RESPONSE_NOT_FOUND))
+                .text();
 
-        return new GptClientResponse(content,
-                LocalDateTime.now().toString());
+        System.out.println(jsonText);
+
+        // TypeReference 정리 필요
+
+        // 최상위 객체의 모든 필드를 탐색
+        List<RecommendationResponse> responses = new ArrayList<>();
+        try {
+            JsonNode rootNode = objectMapper.readTree(jsonText);
+
+            rootNode.fields().forEachRemaining(entry -> {
+                JsonNode arrayNode = entry.getValue();
+                if (arrayNode.isArray()) {
+                    for (JsonNode node : arrayNode) {
+                        try {
+                            RecommendationResponse response = objectMapper.treeToValue(node, RecommendationResponse.class);
+                            responses.add(response);
+                        } catch (JsonProcessingException e) {
+                            throw new RuntimeException("JSON 변환 실패", e);
+                        }
+                    }
+                }
+            });
+
+        } catch (JsonProcessingException e) {
+            throw new CustomException(ErrorCode.GPT_RESPONSE_NOT_FOUND);
+        }
+
+        return responses;
 
     }
 
+    // 사용자의 입력 부분을 프롬프팅 조정해주는 메소드
+    public GptClientRequest prompting(PromptInputRequest promptInputRequest) {
+
+        String promptTemplate = """
+%s 근처에서 %s 카테고리의 장소를 추천해줘.
+방문 시간은 %s에 맞춰.
+결과는 JSON 형식으로 만들어줘. 
+필드 이름은 다음과 같아:
+- name
+- address
+- hours
+- description
+- latitude
+- longtitude
+다른 정보는 넣지 말고, JSON 구조만 반환해. 그리고 장소는 3개를 추천해
+""";
+
+        return new GptClientRequest(String
+                .format(promptTemplate,
+                        promptInputRequest.address(),
+                        promptInputRequest.category(),
+                        promptInputRequest.hours()));
+
+    }
 
 }

--- a/src/main/java/org/dive2025/qdeep/domain/store/dto/response/SavedStoreResponse.java
+++ b/src/main/java/org/dive2025/qdeep/domain/store/dto/response/SavedStoreResponse.java
@@ -1,0 +1,7 @@
+package org.dive2025.qdeep.domain.store.dto.response;
+
+public record SavedStoreResponse (String name,
+                                 String address,
+                                 String hours,
+                                 String description){
+}

--- a/src/main/java/org/dive2025/qdeep/domain/store/entity/Store.java
+++ b/src/main/java/org/dive2025/qdeep/domain/store/entity/Store.java
@@ -1,0 +1,30 @@
+package org.dive2025.qdeep.domain.store.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA용 기본 생성자
+public class Store {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    private String name;
+
+    private String address;
+
+    private String hours;
+
+    private String description;
+
+    private double latitude;
+
+    private double longtitude;
+
+}

--- a/src/main/java/org/dive2025/qdeep/domain/store/repository/StoreRepository.java
+++ b/src/main/java/org/dive2025/qdeep/domain/store/repository/StoreRepository.java
@@ -1,0 +1,11 @@
+package org.dive2025.qdeep.domain.store.repository;
+
+import org.dive2025.qdeep.domain.store.entity.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StoreRepository extends JpaRepository<Store,Long> {
+
+    boolean existsByNameAndAddress(String name,String address);
+}

--- a/src/main/java/org/dive2025/qdeep/domain/store/service/StoreService.java
+++ b/src/main/java/org/dive2025/qdeep/domain/store/service/StoreService.java
@@ -1,0 +1,58 @@
+package org.dive2025.qdeep.domain.store.service;
+
+import org.dive2025.qdeep.domain.recommend.dto.response.RecommendationResponse;
+import org.dive2025.qdeep.domain.recommend.dto.response.RecommendationSaveResponse;
+import org.dive2025.qdeep.domain.recommend.service.GptService;
+import org.dive2025.qdeep.domain.store.dto.response.SavedStoreResponse;
+import org.dive2025.qdeep.domain.store.entity.Store;
+import org.dive2025.qdeep.domain.store.repository.StoreRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class StoreService {
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Transactional
+    public List<SavedStoreResponse> saveAllResponsesBatch(List<RecommendationResponse> responses) {
+        return responses.stream()
+                .map(response -> {
+                    Store store = Store.builder()
+                            .name(response.name())
+                            .address(response.address())
+                            .hours(response.hours())
+                            .description(response.description())
+                            .latitude(response.latitude())
+                            .longtitude(response.longitude())
+                            .build();
+                    checkDuplicationSaving(store); // 이미 등록된건지 체크하는 메소드
+
+                    // DTO로 반환
+                    return new SavedStoreResponse(
+                            store.getName(),
+                            store.getAddress(),
+                            store.getHours(),
+                            store.getDescription()
+                    );
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public Store checkDuplicationSaving(Store store){
+
+        if(storeRepository.existsByNameAndAddress(store.getName()
+                ,store.getAddress())){
+
+            return store;
+        }
+        return storeRepository.save(store);
+    }
+
+}

--- a/src/main/java/org/dive2025/qdeep/domain/user/entity/User.java
+++ b/src/main/java/org/dive2025/qdeep/domain/user/entity/User.java
@@ -1,10 +1,7 @@
 package org.dive2025.qdeep.domain.user.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.dive2025.qdeep.domain.user.Vo.Nickname;
 
 import java.time.LocalDateTime;
@@ -12,7 +9,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 public class User {
 


### PR DESCRIPTION
## 📌 Related Issue

> 관련된 이슈 번호를 적어주세요.  
> 예시: Close 프로젝트 패키지명 변경 #22

- Close #21 

---

## 💬 Description

> 작업한 내용을 간략히 적어주세요.  
> 예시: demo → lettie로 패키지명 변경

1. API 호출결과를 DB에 저장하는 로직 추가 

- Store 도메인 추가 : Store.java , StoreRepository.java , StoreService.java , SavedStoreResponse.java 

2. API 호출결과를 원하는 JSON 형태로 커스텀 

- PromptInputRequest.java : 주소 , 시간대 , 카테고리를 넣어서 원하는 형식의 JSON응답을 요청하는 Request
- RecommendationResponse.java : 지도 API 활용을 위한 경&위도 필드를 받은 Response 
- RecommendationSaveResponse.java : 프론트엔드가 활용할 정보만 보여주도록 받는 Response 
- GptService.java : 요청에 대해서 원하는 결과를 얻도록 하기 위한 프롬프팅 메소드 추가 
- GptController.java : 기능 수정에 맞게 코드 리팩토링 


## 📸 Screenshot

> 변경 사항을 보여주는 스크린샷(또는 GIF)을 첨부해 주세요.  
> 예시: UI 변경 시 Before/After 캡처


<img width="1012" height="778" alt="스크린샷 2025-08-22 오후 9 48 53" src="https://github.com/user-attachments/assets/5b11526f-1dbd-4a5a-a6b8-5f6f90bd92a3" />



## 📢 Notes

> 추가적인 설명이나 참고 사항을 작성해 주세요.  
> 예시: 마이그레이션 주의사항, 의도적인 비동기 처리 등

- (선택)
